### PR TITLE
Debuggability enhancments

### DIFF
--- a/src/Seq.Client.EventLog/App.config
+++ b/src/Seq.Client.EventLog/App.config
@@ -11,7 +11,7 @@
     <applicationSettings>
         <Seq.Client.EventLog.Properties.Settings>
             <setting name="SeqUri" serializeAs="String">
-                <value>http://SERVER:5341</value>
+                <value>http://localhost:5341</value>
             </setting>
             <setting name="ApiKey" serializeAs="String">
                 <value />

--- a/src/Seq.Client.EventLog/EventLogClient.cs
+++ b/src/Seq.Client.EventLog/EventLogClient.cs
@@ -2,6 +2,7 @@
 using System.IO;
 using System.Reflection;
 using Newtonsoft.Json;
+using Serilog;
 
 namespace Seq.Client.EventLog
 {
@@ -34,6 +35,7 @@ namespace Seq.Client.EventLog
                 filePath = configuration;
             }
 
+            Log.Information("Loading listener configuration from {ConfigurationFilePath}", filePath);
             var file = File.ReadAllText(filePath);
 
             _eventLogListeners = JsonConvert.DeserializeObject<List<EventLogListener>>(file);

--- a/src/Seq.Client.EventLog/EventLogClient.cs
+++ b/src/Seq.Client.EventLog/EventLogClient.cs
@@ -1,0 +1,66 @@
+﻿using System.Collections.Generic;
+using System.IO;
+using System.Reflection;
+using Newtonsoft.Json;
+
+namespace Seq.Client.EventLog
+{
+    class EventLogClient
+    {
+        private List<EventLogListener> _eventLogListeners;
+
+        public void Start(string configuration = null)
+        {
+            LoadListeners(configuration);
+            ValidateListeners();
+            StartListeners();
+        }
+
+        public void Stop()
+        {
+            StopListeners();
+        }
+
+        private void LoadListeners(string configuration)
+        {
+            string filePath;
+            if (configuration == null)
+            {
+                var directory = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
+                filePath = Path.Combine(directory ?? ".", "EventLogListeners.json");
+            }
+            else
+            {
+                filePath = configuration;
+            }
+
+            var file = File.ReadAllText(filePath);
+
+            _eventLogListeners = JsonConvert.DeserializeObject<List<EventLogListener>>(file);
+        }
+
+        private void ValidateListeners()
+        {
+            foreach (var listener in _eventLogListeners)
+            {
+                listener.Validate();
+            }
+        }
+
+        private void StartListeners()
+        {
+            foreach (var listener in _eventLogListeners)
+            {
+                listener.Start();
+            }
+        }
+
+        private void StopListeners()
+        {
+            foreach (var listener in _eventLogListeners)
+            {
+                listener.Stop();
+            }
+        }
+    }
+}

--- a/src/Seq.Client.EventLog/EventLogListener.cs
+++ b/src/Seq.Client.EventLog/EventLogListener.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Net.Http;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
 using Seq.Client.EventLog.Properties;
@@ -22,6 +23,9 @@ namespace Seq.Client.EventLog
         public List<string> Sources { get; set; }
 
         private System.Diagnostics.EventLog _eventLog;
+        private readonly CancellationTokenSource _cancel = new CancellationTokenSource();
+        private Task _retroactiveLoadingTask;
+        private volatile bool _started;
 
         public void Validate()
         {
@@ -35,6 +39,8 @@ namespace Seq.Client.EventLog
         {
             try
             {
+                Serilog.Log.Information("Starting listener for {LogName} on {MachineName}", LogName, MachineName ?? ".");
+
                 _eventLog = new System.Diagnostics.EventLog(LogName);
 
                 if (!string.IsNullOrWhiteSpace(MachineName))
@@ -50,13 +56,16 @@ namespace Seq.Client.EventLog
 
                 if (ProcessRetroactiveEntries)
                 {
-                    // Start as a new task so it doesn't block the startup of the service
-                    Task.Factory.StartNew(HandleRetroactiveEntries);
+                    // Start as a new task so it doesn't block the startup of the service. This has
+                    // to go on its own thread to avoid deadlocking via `Wait()`/`Result`.
+                    _retroactiveLoadingTask = Task.Factory.StartNew(HandleRetroactiveEntries, TaskCreationOptions.LongRunning);
                 }
+
+                _started = true;
             }
-            catch (Exception)
+            catch (Exception ex)
             {
-                
+                Serilog.Log.Error(ex, "Failed to start listener for {LogName} on {MachineName}", LogName, MachineName ?? ".");
             }
         }
 
@@ -64,60 +73,94 @@ namespace Seq.Client.EventLog
         {
             try
             {
+                if (!_started)
+                    return;
+
+                _cancel.Cancel();
                 _eventLog.EnableRaisingEvents = false;
+
+                // This would be a little racy if start and stop were ever called on differen threads, but
+                // this isn't done, currently.
+                _retroactiveLoadingTask?.Wait();
+
                 _eventLog.Close();
                 _eventLog.Dispose();
             }
             catch (Exception ex)
             {
-                
+                Serilog.Log.Error(ex, "Failed to stop listener");
             }
         }
 
         private void HandleRetroactiveEntries()
         {
-            foreach (EventLogEntry entry in _eventLog.Entries)
+            try
             {
-                HandleEventLogEntry(entry, _eventLog.Log);
+                Serilog.Log.Information("Processing {EntryCount} retroactive entries in {LogName}", _eventLog.Entries.Count, LogName);
+
+                foreach (EventLogEntry entry in _eventLog.Entries)
+                {
+                    if (_cancel.IsCancellationRequested)
+                    {
+                        Serilog.Log.Warning("Cancelling retroactive event loading");
+                        return;
+                    }
+
+                    HandleEventLogEntry(entry, _eventLog.Log);
+                }
+            }
+            catch (Exception ex)
+            {
+                Serilog.Log.Error(ex, "Failed to handle retroactive entries");
             }
         }
 
         private void HandleEventLogEntry(EventLogEntry entry, string logName)
         {
-            // Don't send the entry to Seq if it doesn't match the filtered log levels, event IDs, or sources
-            if (LogLevels != null && LogLevels.Count > 0 && !LogLevels.Contains(entry.EntryType))
-                return;
+            try
+            {
+                // Don't send the entry to Seq if it doesn't match the filtered log levels, event IDs, or sources
+                if (LogLevels != null && LogLevels.Count > 0 && !LogLevels.Contains(entry.EntryType))
+                    return;
 
-            if (EventIds != null && EventIds.Count > 0 && !EventIds.Contains(entry.EventID))
-                return;
+                // EventID is obsolete
+#pragma warning disable 618
+                if (EventIds != null && EventIds.Count > 0 && !EventIds.Contains(entry.EventID))
+#pragma warning restore 618
+                    return;
 
-            if (Sources != null && Sources.Count > 0 && !Sources.Contains(entry.Source))
-                return;
+                if (Sources != null && Sources.Count > 0 && !Sources.Contains(entry.Source))
+                    return;
 
-            PostRawEvents(entry.ToDto(logName));
+                PostRawEvents(entry.ToDto(logName));
+            }
+            catch (Exception ex)
+            {
+                Serilog.Log.Error(ex, "Failed to handle an event log entry");
+            }
         }
 
         private static void PostRawEvents(RawEvents rawEvents)
         {
-            try
+            using (var client = new HttpClient())
             {
-                using (var client = new HttpClient())
+                var uri = Settings.Default.SeqUri + "/api/events/raw";
+
+                if (!string.IsNullOrWhiteSpace(Settings.Default.ApiKey))
                 {
-                    var uri = Settings.Default.SeqUri + "/api/events/raw";
-
-                    if (!string.IsNullOrWhiteSpace(Settings.Default.ApiKey))
-                    {
-                        uri += "?apiKey=" + Settings.Default.ApiKey;
-                    }
-
-                    var content = new StringContent(JsonConvert.SerializeObject(rawEvents, Formatting.None),
-                        Encoding.UTF8, "application/json");
-                    var result = client.PostAsync(uri, content).Result;
+                    uri += "?apiKey=" + Settings.Default.ApiKey;
                 }
-            }
-            catch (Exception)
-            {
 
+                var content = new StringContent(
+                    JsonConvert.SerializeObject(rawEvents, Formatting.None),
+                    Encoding.UTF8,
+                    "application/json");
+
+                var result = client.PostAsync(uri, content).Result;
+                if (!result.IsSuccessStatusCode)
+                {
+                    Serilog.Log.Error("Received failure status code {StatusCode} from Seq: {ReasonPhrase}", result.StatusCode, result.ReasonPhrase);
+                }
             }
         }
     }

--- a/src/Seq.Client.EventLog/EventLogListener.cs
+++ b/src/Seq.Client.EventLog/EventLogListener.cs
@@ -1,12 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Net.Http;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-using Newtonsoft.Json;
-using Seq.Client.EventLog.Properties;
 
 namespace Seq.Client.EventLog
 {
@@ -15,7 +11,7 @@ namespace Seq.Client.EventLog
         public string LogName { get; set; }
         public string MachineName { get; set; }
         public bool ProcessRetroactiveEntries { get; set; }
-        
+
         // These properties allow for the filtering of events that will be sent to Seq.
         // If they are not specified in the JSON, all events in the log will be sent.
         public List<EventLogEntryType> LogLevels { get; set; }
@@ -41,32 +37,34 @@ namespace Seq.Client.EventLog
             {
                 Serilog.Log.Information("Starting listener for {LogName} on {MachineName}", LogName, MachineName ?? ".");
 
-                _eventLog = new System.Diagnostics.EventLog(LogName);
-
-                if (!string.IsNullOrWhiteSpace(MachineName))
-                {
-                    _eventLog.MachineName = MachineName;
-                }
-                
-                _eventLog.EntryWritten += (sender, args) =>
-                {
-                    HandleEventLogEntry(args.Entry, _eventLog.Log);
-                };
-                _eventLog.EnableRaisingEvents = true;
+                _eventLog = OpenEventLog();
 
                 if (ProcessRetroactiveEntries)
                 {
                     // Start as a new task so it doesn't block the startup of the service. This has
                     // to go on its own thread to avoid deadlocking via `Wait()`/`Result`.
-                    _retroactiveLoadingTask = Task.Factory.StartNew(HandleRetroactiveEntries, TaskCreationOptions.LongRunning);
+                    _retroactiveLoadingTask = Task.Factory.StartNew(SendRetroactiveEntries, TaskCreationOptions.LongRunning);
                 }
 
+                _eventLog.EntryWritten += OnEntryWritten;
+                _eventLog.EnableRaisingEvents = true;
                 _started = true;
             }
             catch (Exception ex)
             {
                 Serilog.Log.Error(ex, "Failed to start listener for {LogName} on {MachineName}", LogName, MachineName ?? ".");
             }
+        }
+
+        System.Diagnostics.EventLog OpenEventLog()
+        {
+            var eventLog = new System.Diagnostics.EventLog(LogName);
+            if (!string.IsNullOrWhiteSpace(MachineName))
+            {
+                eventLog.MachineName = MachineName;
+            }
+
+            return eventLog;
         }
 
         public void Stop()
@@ -85,6 +83,8 @@ namespace Seq.Client.EventLog
 
                 _eventLog.Close();
                 _eventLog.Dispose();
+
+                Serilog.Log.Information("Listener stopped");
             }
             catch (Exception ex)
             {
@@ -92,47 +92,37 @@ namespace Seq.Client.EventLog
             }
         }
 
-        private void HandleRetroactiveEntries()
+        private void SendRetroactiveEntries()
         {
             try
             {
-                Serilog.Log.Information("Processing {EntryCount} retroactive entries in {LogName}", _eventLog.Entries.Count, LogName);
-
-                foreach (EventLogEntry entry in _eventLog.Entries)
+                using (var eventLog = OpenEventLog())
                 {
-                    if (_cancel.IsCancellationRequested)
-                    {
-                        Serilog.Log.Warning("Canceling retroactive event loading");
-                        return;
-                    }
+                    Serilog.Log.Information("Processing {EntryCount} retroactive entries in {LogName}", eventLog.Entries.Count, LogName);
 
-                    HandleEventLogEntry(entry, _eventLog.Log);
+                    foreach (EventLogEntry entry in eventLog.Entries)
+                    {
+                        if (_cancel.IsCancellationRequested)
+                        {
+                            Serilog.Log.Warning("Canceling retroactive event loading");
+                            return;
+                        }
+
+                        HandleEventLogEntry(entry, eventLog.Log).GetAwaiter().GetResult();
+                    }
                 }
             }
             catch (Exception ex)
             {
-                Serilog.Log.Error(ex, "Failed to handle retroactive entries");
+                Serilog.Log.Error(ex, "Failed to send retroactive entries in {LogName} on {MachineName}", LogName, MachineName ?? ".");
             }
         }
 
-        private void HandleEventLogEntry(EventLogEntry entry, string logName)
+        private void OnEntryWritten(object sender, EntryWrittenEventArgs args)
         {
             try
             {
-                // Don't send the entry to Seq if it doesn't match the filtered log levels, event IDs, or sources
-                if (LogLevels != null && LogLevels.Count > 0 && !LogLevels.Contains(entry.EntryType))
-                    return;
-
-                // EventID is obsolete
-#pragma warning disable 618
-                if (EventIds != null && EventIds.Count > 0 && !EventIds.Contains(entry.EventID))
-#pragma warning restore 618
-                    return;
-
-                if (Sources != null && Sources.Count > 0 && !Sources.Contains(entry.Source))
-                    return;
-
-                PostRawEvents(entry.ToDto(logName));
+                HandleEventLogEntry(args.Entry, _eventLog.Log).GetAwaiter().GetResult();
             }
             catch (Exception ex)
             {
@@ -140,28 +130,22 @@ namespace Seq.Client.EventLog
             }
         }
 
-        private static void PostRawEvents(RawEvents rawEvents)
+        private async Task HandleEventLogEntry(EventLogEntry entry, string logName)
         {
-            using (var client = new HttpClient())
-            {
-                var uri = Settings.Default.SeqUri + "/api/events/raw";
+            // Don't send the entry to Seq if it doesn't match the filtered log levels, event IDs, or sources
+            if (LogLevels != null && LogLevels.Count > 0 && !LogLevels.Contains(entry.EntryType))
+                return;
 
-                if (!string.IsNullOrWhiteSpace(Settings.Default.ApiKey))
-                {
-                    uri += "?apiKey=" + Settings.Default.ApiKey;
-                }
+            // EventID is obsolete
+#pragma warning disable 618
+            if (EventIds != null && EventIds.Count > 0 && !EventIds.Contains(entry.EventID))
+#pragma warning restore 618
+                return;
 
-                var content = new StringContent(
-                    JsonConvert.SerializeObject(rawEvents, Formatting.None),
-                    Encoding.UTF8,
-                    "application/json");
+            if (Sources != null && Sources.Count > 0 && !Sources.Contains(entry.Source))
+                return;
 
-                var result = client.PostAsync(uri, content).Result;
-                if (!result.IsSuccessStatusCode)
-                {
-                    Serilog.Log.Error("Received failure status code {StatusCode} from Seq: {ReasonPhrase}", result.StatusCode, result.ReasonPhrase);
-                }
-            }
+            await SeqApi.PostRawEvents(entry.ToDto(logName));
         }
     }
 }

--- a/src/Seq.Client.EventLog/EventLogListener.cs
+++ b/src/Seq.Client.EventLog/EventLogListener.cs
@@ -16,7 +16,7 @@ namespace Seq.Client.EventLog
         public string MachineName { get; set; }
         public bool ProcessRetroactiveEntries { get; set; }
         
-        // These properties allow for the filterting of events that will be sent to Seq.
+        // These properties allow for the filtering of events that will be sent to Seq.
         // If they are not specified in the JSON, all events in the log will be sent.
         public List<EventLogEntryType> LogLevels { get; set; }
         public List<int> EventIds { get; set; }
@@ -31,7 +31,7 @@ namespace Seq.Client.EventLog
         {
             if (string.IsNullOrWhiteSpace(LogName))
             {
-                throw new InvalidOperationException("A LogName must be specified for the listener.");
+                throw new InvalidOperationException($"A {nameof(LogName)} must be specified for the listener.");
             }
         }
 
@@ -79,7 +79,7 @@ namespace Seq.Client.EventLog
                 _cancel.Cancel();
                 _eventLog.EnableRaisingEvents = false;
 
-                // This would be a little racy if start and stop were ever called on differen threads, but
+                // This would be a little racy if start and stop were ever called on different threads, but
                 // this isn't done, currently.
                 _retroactiveLoadingTask?.Wait();
 
@@ -102,7 +102,7 @@ namespace Seq.Client.EventLog
                 {
                     if (_cancel.IsCancellationRequested)
                     {
-                        Serilog.Log.Warning("Cancelling retroactive event loading");
+                        Serilog.Log.Warning("Canceling retroactive event loading");
                         return;
                     }
 

--- a/src/Seq.Client.EventLog/Extensions.cs
+++ b/src/Seq.Client.EventLog/Extensions.cs
@@ -38,7 +38,9 @@ namespace Seq.Client.EventLog
                         Properties = new Dictionary<string, object>
                         {
                             { "MachineName", entry.MachineName },
+#pragma warning disable 618
                             { "EventId", entry.EventID },
+#pragma warning restore 618
                             { "InstanceId", entry.InstanceId },
                             { "Source", entry.Source },
                             { "Category", entry.CategoryNumber },

--- a/src/Seq.Client.EventLog/Program.cs
+++ b/src/Seq.Client.EventLog/Program.cs
@@ -2,6 +2,8 @@
 using System.Configuration.Install;
 using System.Reflection;
 using System.ServiceProcess;
+using System.Threading;
+using Serilog;
 
 namespace Seq.Client.EventLog
 {
@@ -10,7 +12,8 @@ namespace Seq.Client.EventLog
         /// <summary>
         /// The main entry point for the application.
         /// The service can be installed or uninstalled from the command line
-        /// by passing the /install or /uninstall argument.
+        /// by passing the /install or /uninstall argument, and can be run
+        /// interactively by specifying the path to the JSON configuration file.
         /// </summary>
         public static void Main(string[] args)
         {
@@ -26,13 +29,55 @@ namespace Seq.Client.EventLog
                     case "/uninstall":
                         ManagedInstallerClass.InstallHelper(new[] { "/u", Assembly.GetExecutingAssembly().Location });
                         break;
+                    default:
+                        RunInteractive(parameter);
+                        break;
                 }
             }
             else
             {
-                // Run the service
-                ServiceBase.Run(new Service());
+                RunService();
             }
+        }
+
+        static void RunInteractive(string configFilePath)
+        {
+            Log.Logger = new LoggerConfiguration()
+                .WriteTo.Console()
+                .CreateLogger();
+
+            try
+            {
+                Log.Information("Running interactively");
+
+                var client = new EventLogClient();
+                client.Start(configFilePath);
+
+                var done = new ManualResetEvent(false);
+                Console.CancelKeyPress += (s, e) =>
+                {
+                    Log.Information("Ctrl+C pressed, stopping");
+                    client.Stop();
+                    done.Set();
+                };
+
+                done.WaitOne();
+                Log.Information("Stopped");
+            }
+            catch (Exception ex)
+            {
+                Log.Fatal(ex, "An unhandled exception occurred");
+                Environment.ExitCode = 1;
+            }
+            finally
+            {
+                Log.CloseAndFlush();
+            }
+        }
+
+        static void RunService()
+        {
+            ServiceBase.Run(new Service());
         }
     }
 }

--- a/src/Seq.Client.EventLog/Program.cs
+++ b/src/Seq.Client.EventLog/Program.cs
@@ -21,6 +21,11 @@ namespace Seq.Client.EventLog
             if (Environment.UserInteractive)
             {
                 var parameter = string.Concat(args);
+                if (string.IsNullOrWhiteSpace(parameter))
+                {
+                    parameter = null;
+                }
+
                 switch (parameter)
                 {
                     case "/install":

--- a/src/Seq.Client.EventLog/Seq.Client.EventLog.csproj
+++ b/src/Seq.Client.EventLog/Seq.Client.EventLog.csproj
@@ -33,6 +33,9 @@
     <WarningLevel>4</WarningLevel>
     <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
+  <PropertyGroup>
+    <StartupObject />
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
@@ -77,6 +80,7 @@
     </Compile>
     <Compile Include="RawEvent.cs" />
     <Compile Include="RawEvents.cs" />
+    <Compile Include="SeqApi.cs" />
     <Compile Include="Service.cs">
       <SubType>Component</SubType>
     </Compile>

--- a/src/Seq.Client.EventLog/Seq.Client.EventLog.csproj
+++ b/src/Seq.Client.EventLog/Seq.Client.EventLog.csproj
@@ -5,7 +5,7 @@
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{B14232BD-B051-4255-9DEC-81EA174660E8}</ProjectGuid>
-    <OutputType>WinExe</OutputType>
+    <OutputType>Exe</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Seq.Client.EventLog</RootNamespace>
     <AssemblyName>Seq.Client.EventLog</AssemblyName>
@@ -38,6 +38,12 @@
       <HintPath>..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="Serilog, Version=2.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
+      <HintPath>..\packages\Serilog.2.7.1\lib\net46\Serilog.dll</HintPath>
+    </Reference>
+    <Reference Include="Serilog.Sinks.Console, Version=3.1.1.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
+      <HintPath>..\packages\Serilog.Sinks.Console.3.1.1\lib\net45\Serilog.Sinks.Console.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.DataAnnotations" />
     <Reference Include="System.Configuration.Install" />
@@ -52,6 +58,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="EventLogClient.cs" />
     <Compile Include="EventLogListener.cs" />
     <Compile Include="Extensions.cs" />
     <Compile Include="ProjectInstaller.cs">

--- a/src/Seq.Client.EventLog/Seq.Client.EventLog.csproj
+++ b/src/Seq.Client.EventLog/Seq.Client.EventLog.csproj
@@ -44,6 +44,9 @@
     <Reference Include="Serilog.Sinks.Console, Version=3.1.1.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
       <HintPath>..\packages\Serilog.Sinks.Console.3.1.1\lib\net45\Serilog.Sinks.Console.dll</HintPath>
     </Reference>
+    <Reference Include="Serilog.Sinks.File, Version=2.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
+      <HintPath>..\packages\Serilog.Sinks.File.4.0.0\lib\net45\Serilog.Sinks.File.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.DataAnnotations" />
     <Reference Include="System.Configuration.Install" />

--- a/src/Seq.Client.EventLog/SeqApi.cs
+++ b/src/Seq.Client.EventLog/SeqApi.cs
@@ -1,0 +1,34 @@
+﻿using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+using Seq.Client.EventLog.Properties;
+
+namespace Seq.Client.EventLog
+{
+    static class SeqApi
+    {
+        public static readonly HttpClient HttpClient = new HttpClient();
+
+        public static async Task PostRawEvents(RawEvents rawEvents)
+        {
+            var uri = Settings.Default.SeqUri + "/api/events/raw";
+
+            if (!string.IsNullOrWhiteSpace(Settings.Default.ApiKey))
+            {
+                uri += "?apiKey=" + Settings.Default.ApiKey;
+            }
+
+            var content = new StringContent(
+                JsonConvert.SerializeObject(rawEvents, Formatting.None),
+                Encoding.UTF8,
+                "application/json");
+
+            var result = await HttpClient.PostAsync(uri, content).ConfigureAwait(false);
+            if (!result.IsSuccessStatusCode)
+            {
+                Serilog.Log.Error("Received failure status code {StatusCode} from Seq: {ReasonPhrase}", result.StatusCode, result.ReasonPhrase);
+            }
+        }
+    }
+}

--- a/src/Seq.Client.EventLog/Service.cs
+++ b/src/Seq.Client.EventLog/Service.cs
@@ -1,14 +1,10 @@
-﻿using System.Collections.Generic;
-using System.IO;
-using System.Reflection;
-using System.ServiceProcess;
-using Newtonsoft.Json;
+﻿using System.ServiceProcess;
 
 namespace Seq.Client.EventLog
 {
     public partial class Service : ServiceBase
     {
-        private List<EventLogListener> _eventLogListeners;
+        private readonly EventLogClient _client = new EventLogClient();
 
         #region Windows Service Base
         public Service()
@@ -18,48 +14,13 @@ namespace Seq.Client.EventLog
 
         protected override void OnStart(string[] args)
         {
-            LoadListeners();
-            ValidateListeners();
-            StartListeners();
+            _client.Start();
         }
         
         protected override void OnStop()
         {
-            StopListeners();
+            _client.Stop();
         }
         #endregion
-
-        private void LoadListeners()
-        {
-            var directory = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
-            var filePath = Path.Combine(directory, "EventLogListeners.json");
-            var file = File.ReadAllText(filePath);
-
-            _eventLogListeners = JsonConvert.DeserializeObject<List<EventLogListener>>(file);
-        }
-
-        private void ValidateListeners()
-        {
-            foreach (var listener in _eventLogListeners)
-            {
-                listener.Validate();
-            }
-        }
-
-        private void StartListeners()
-        {
-            foreach (var listener in _eventLogListeners)
-            {
-                listener.Start();
-            }
-        }
-
-        private void StopListeners()
-        {
-            foreach (var listener in _eventLogListeners)
-            {
-                listener.Stop();
-            }
-        }
     }
 }

--- a/src/Seq.Client.EventLog/packages.config
+++ b/src/Seq.Client.EventLog/packages.config
@@ -3,4 +3,5 @@
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net462" />
   <package id="Serilog" version="2.7.1" targetFramework="net462" />
   <package id="Serilog.Sinks.Console" version="3.1.1" targetFramework="net462" />
+  <package id="Serilog.Sinks.File" version="4.0.0" targetFramework="net462" />
 </packages>

--- a/src/Seq.Client.EventLog/packages.config
+++ b/src/Seq.Client.EventLog/packages.config
@@ -1,4 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net462" />
+  <package id="Serilog" version="2.7.1" targetFramework="net462" />
+  <package id="Serilog.Sinks.Console" version="3.1.1" targetFramework="net462" />
 </packages>


### PR DESCRIPTION
Hi! Apologies for the large, unsolicited pull request.

I'm helping a customer figure out why this application no longer functions for them with Seq 5. We don't have much to go on, so I've made some changes on my fork to allow the app to be run as a console application, and to report any internal errors/exceptions.

When debugging in VS, I start it with the `EventLogListeners.json` file as a command-line argument:

![image](https://user-images.githubusercontent.com/342712/48964371-71c9af80-eff1-11e8-9abc-38f9d008ff4c.png)

The `Environment.UserInteractive` check then causes it to run as a console app, like this:

![image](https://user-images.githubusercontent.com/342712/48964358-39c26c80-eff1-11e8-81a3-1f5388d9993c.png)

This is my first cut and I need to do some more testing before I'd suggest it's ready to review, but I thought I'd send a heads-up in case you have suggestions, would prefer to do things differently, or have other ideas I could implement (I'm not deeply attached to any of these changes).

Also completely happy just to maintain this as a personal fork, if it's not the direction you want to take things :-)

All the best, and thanks for publishing a much-needed project!